### PR TITLE
Only restart macromilter.service if it has been started

### DIFF
--- a/macromilter/macromilter.logrotate
+++ b/macromilter/macromilter.logrotate
@@ -10,7 +10,7 @@
     create 640 postfix postfix
     sharedscripts
     postrotate
-        /usr/bin/systemctl restart macromilter.service > /dev/null
+        systemctl try-restart macromilter.service
     endscript
 }
 


### PR DESCRIPTION
Only restart macromilter.service if it has been started, show errors (should be silent except for errors)