### PR TITLE
Switch from MD5 to SHA512 hash algorithm

### DIFF
--- a/macromilter/macromilter.py
+++ b/macromilter/macromilter.py
@@ -211,7 +211,7 @@ class MacroMilter(Milter.Base):
 
 	def fileHasAlreadyBeenParsed(self, data):
 		# generate Hash from file
-		hash_data = hashlib.md5(data).hexdigest()
+		hash_data = hashlib.sha512(data).hexdigest()
 		# check if file is already parsed
 		if hash_data in hashtable:
 			log.warning("Attachment %s already parsed ! REJECT" % hash_data)
@@ -220,7 +220,7 @@ class MacroMilter(Milter.Base):
 			return False
 
 	def addHashtoDB(self, data):
-		hash_data = hashlib.md5(data).hexdigest()
+		hash_data = hashlib.sha512(data).hexdigest()
 		hashtable.add(hash_data)
 		with open(HASHTABLE_PATH, "a") as hashdb:
 			hashdb.write(hash_data + '\n')
@@ -267,7 +267,7 @@ class MacroMilter(Milter.Base):
 						m = mraptor.MacroRaptor(vba_code_all_modules)
 						m.scan()
 						if m.suspicious:
-							# Add MD5 to the database
+							# Add SHA512 hash to database
 							self.addHashtoDB(attachment)
 							# Replace the attachment or reject it
 							if REJECT_MESSAGE:


### PR DESCRIPTION
MD5 has known hash collision weaknesses, however this PR to SHA512 will invalidate all previous MD5 hashes in the existing hash table files out there.