### PR TITLE
Configurable umask for unix socket

### DIFF
--- a/macromilter/config.ini
+++ b/macromilter/config.ini
@@ -2,6 +2,8 @@
 # at postfix smtpd_milters = inet:127.0.0.1:3690
 # bind to unix or tcp socket "inet:port@ip" or "/<path>/<to>/<something>.sock"
 SOCKET = inet:3690@127.0.0.1 
+# Set umask for unix socket, e.g. 0077 for group writable
+UMASK = 0077
 # Milter timout in seconds
 TIMEOUT = 30  
 # Define the max size for each message in bytes (~50BM)

--- a/macromilter/macromilter.py
+++ b/macromilter/macromilter.py
@@ -97,6 +97,7 @@ if os.path.isfile(CONFIG):
 	config = SafeConfigParser()
 	config.read(CONFIG)
 	SOCKET = config.get('Milter', 'SOCKET')
+	UMASK = int(config.get('Milter', 'UMASK'), base=0)
 	TIMEOUT = config.getint('Milter', 'TIMEOUT')
 	MAX_FILESIZE = config.getint('Milter', 'MAX_FILESIZE')
 	CFG_DIR = config.get('Milter', 'CFG_DIR')
@@ -451,6 +452,10 @@ def main():
 	log.info('Starting MarcoMilter v%s - listening on %s' % (__version__, SOCKET))
 	log.debug('Python version: %s' % sys.version)
 	sys.stdout.flush()
+
+	# ensure desired permissions on unix socket
+	os.umask(UMASK);
+
 	# set the "last" fall back to ACCEPT if exception occur
 	Milter.set_exception_policy(Milter.ACCEPT)
 


### PR DESCRIPTION
While you might be a TCP fan, this suggestion only enhances the Unix socket. Usage:

In `/etc/macromilter/config.ini` set:

    SOCKET = /run/macromilter/macromilter.sock
    UMASK = 0077  # 0007 if MacroMilter is run as user postfix

If MacroMilter is run as as non-postfix user (e.g. as macromilter user), run:

    usermod -a -G macromilter postfix

Configure postfix to use the Unix socket:

    postconf -e smtpd_milters=unix:/run/macromilter/macromilter.sock