### PR TITLE
Ensure logfile and hashtable are not world readable

### DIFF
--- a/macromilter/macromilter.py
+++ b/macromilter/macromilter.py
@@ -124,6 +124,9 @@ hash_to_write = None
 hashtable = None
 WhiteList = None
 
+# Ensure logfile and hashtable are not world readable
+os.umask(0o0037)
+
 # Custom expetion class for archive bomb exception
 class ToManyZipException(Exception):
 	pass


### PR DESCRIPTION
From my point of view, #18 is not fixed by 0a2d6d8 given `os.makedirs(LOGFILE_DIR,0o0750)` only works if MacroMilter is started as `root` but not when MacroMilter is started as non-privileged user, e.g. `postfix`, because that user is by default unable to create a directory in `/var/log/` anyway. Thus this patch suggests to change the process' umask in general to avoid world readable files.